### PR TITLE
The "reload" option is now based on a state name

### DIFF
--- a/src/scripts/module.js
+++ b/src/scripts/module.js
@@ -56,11 +56,16 @@
       $provide.decorator('$state', function ($delegate) {
         var originalTransitionTo = $delegate.transitionTo;
         $delegate.transitionTo = function () {
-          var optionsIndex = 2;
-          arguments[optionsIndex] = angular.extend({
-            reload: true
-          }, arguments[optionsIndex]);
-          return originalTransitionTo.apply(originalTransitionTo, arguments);
+          // Make sure we're dealing with a state that has a name
+          if (angular.isString(arguments[0])) {
+            var optionsIndex = 2;
+            arguments[optionsIndex] = angular.extend({
+              reload: arguments[0]
+            }, arguments[optionsIndex]);
+            return originalTransitionTo.apply(originalTransitionTo, arguments);
+          }
+          // Return original object if nothing has been changed
+          return originalTransitionTo;
         };
         return $delegate;
       });


### PR DESCRIPTION
If you have a similar setup as the person in this issue a `reload:
true` will break a page:
https://github.com/angular-ui/ui-router/issues/2753

I'm still not entirely sure why this reload needs to be there at all or in what scenario it will be useful though.

However, I think with my changes that functionality is still intact but it doesn't give errors with a nested setup like describes above.
